### PR TITLE
iine tableのDDLを追加

### DIFF
--- a/infra/compose.yaml
+++ b/infra/compose.yaml
@@ -6,6 +6,7 @@ services:
       - 3306:3306
     volumes:
       - mariadb:/var/lib/mysql
+      - ./ddl.sql:/docker-entrypoint-initdb.d/ddl.sql
     environment:
       MARIADB_ROOT_PASSWORD: password
       MARIADB_DATABASE: iine

--- a/infra/ddl.sql
+++ b/infra/ddl.sql
@@ -1,0 +1,38 @@
+/*!999999\- enable the sandbox mode */
+-- MariaDB dump 10.19  Distrib 10.6.18-MariaDB, for debian-linux-gnu (x86_64)
+--
+-- Host: localhost    Database: iine
+-- ------------------------------------------------------
+-- Server version    10.6.18-MariaDB-0ubuntu0.22.04.1
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `iine`
+--
+
+DROP TABLE IF EXISTS `iine`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `iine` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `user` char(100) DEFAULT NULL,
+  `world` char(50) DEFAULT NULL,
+  `title` char(20) DEFAULT NULL,
+  `x` int(11) DEFAULT NULL,
+  `y` int(11) DEFAULT NULL,
+  `z` int(11) DEFAULT NULL,
+  `iine` int(11) DEFAULT NULL,
+  `date` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=55 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;


### PR DESCRIPTION
Titleの通り。
MariaDBをDockerで立ち上げた際、初回起動時は自動でこのDDLを実行してtableを作成する。