### PR TITLE
Set MariaDB's wait timeout 60 seconds

### DIFF
--- a/infra/compose.yaml
+++ b/infra/compose.yaml
@@ -10,6 +10,7 @@ services:
     environment:
       MARIADB_ROOT_PASSWORD: password
       MARIADB_DATABASE: iine
+    command: --wait-timeout=60
 
 volumes:
   mariadb:


### PR DESCRIPTION
MariaDBのtimeoutを60秒に設定。
反映するには
```
docker compose down
docker compose up -d
```
で、設定を確認するには
```
docker compose exec db bash
mysql -u root -ppassword
show global variables like '%wait%';
```
で `wait_timeout` が `60` であることを確認する。